### PR TITLE
Engops 6073 new java17 link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ RUN apt-get install -y openjdk-17-jre-headless
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-11.0.16_8
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-17
 
-# Create symlink to retired test script
+# Create symlinks to retired test script
 RUN ln -s /script/test.sh /script/test-cc.sh
 RUN chmod +x /script/test-cc.sh
+RUN ln -s /script/sonar.sh /script/sonar-cc.sh
+RUN chmod +x /script/sonar-cc.sh
 
 USER jenkins
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ RUN useradd --uid 1001 jenkins && mkdir /home/jenkins && chown jenkins:jenkins /
 RUN apt-get update
 RUN apt-get install -y openjdk-17-jre-headless
 
-# Create symlink to allow the Java environment varible to point to the locally installed path
+# Create symlinks to allow the Java environment varible to point to the locally installed path
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-11.0.16_8
+RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-17
 
 USER jenkins
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN apt-get install -y openjdk-17-jre-headless
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-11.0.16_8
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-17
 
+# Create symlink to retired test script
+RUN ln -s /script/test.sh /script/test-cc.sh
+RUN chmod +x /script/test-cc.sh
+
 USER jenkins
 
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /src
 
 COPY --chown=jenkins:jenkins ./scripts /scripts
 
-# Create symlinks to retired test script
+# Create symlinks to renamed test scripts
 RUN ln -s /scripts/test.sh /scripts/test-cc.sh
 RUN ln -s /scripts/sonar.sh /scripts/sonar-cc.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,15 @@ RUN apt-get install -y openjdk-17-jre-headless
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-11.0.16_8
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-17
 
-# Create symlinks to retired test script
-RUN ln -s /scripts/test.sh /scripts/test-cc.sh
-RUN ln -s /scripts/sonar.sh /scripts/sonar-cc.sh
-
 USER jenkins
 
 WORKDIR /src
 
 COPY --chown=jenkins:jenkins ./scripts /scripts
+
+# Create symlinks to retired test script
+RUN ln -s /scripts/test.sh /scripts/test-cc.sh
+RUN ln -s /scripts/sonar.sh /scripts/sonar-cc.sh
 
 # Install dotnet tools
 RUN dotnet tool install --global dotnet-sonarscanner

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,8 @@ RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-11.0.16_8
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-17
 
 # Create symlinks to retired test script
-RUN ln -s /script/test.sh /script/test-cc.sh
-RUN chmod +x /script/test-cc.sh
-RUN ln -s /script/sonar.sh /script/sonar-cc.sh
-RUN chmod +x /script/sonar-cc.sh
+RUN ln -s /scripts/test.sh /scripts/test-cc.sh
+RUN ln -s /scripts/sonar.sh /scripts/sonar-cc.sh
 
 USER jenkins
 


### PR DESCRIPTION
Proposals, households and at least one other pipeline run the sonar scan on this dotnet docker container.  The container HAS a Java 17 install on it and is already running scans using it, but because it is located in a different folder than the EC2 Ubuntu Jenkins agent the pipelines run on, it will confuse our crafty tooling post SQ upgrade.  You can see this was already worked around with the symlink on line 12.  We are just using the same approach here.

The scripts baked into the image have also undergone a name change since the last publish.  Did the 8.0 tag move under our feet?  Anyways, rather than change the pipelines, I used a symlink approach to address this as well.

The runs below are against the new upgraded SQ server.

Before:
https://jenkins.vestmarkeng.com/job/Endeavour/job/proposals-api/job/quality-gate/job/ENGOPS-6073-sonar-scanner-using-java17/2/

After:
https://jenkins.vestmarkeng.com/job/Endeavour/job/proposals-api/job/quality-gate/job/ENGOPS-6073-sonar-scanner-using-java17/15/

Thank you.
