### PR TITLE
ENGOPS-6073 target proper release dotnet8 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,19 @@ RUN useradd --uid 1001 jenkins && mkdir /home/jenkins && chown jenkins:jenkins /
 RUN apt-get update
 RUN apt-get install -y openjdk-17-jre-headless
 
-# Create symlink to allow the Java environment varible to point to the locally installed path
+# Create symlinks to allow the Java environment varible to point to the locally installed path
 RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-11.0.16_8
+RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/openjdk-17
 
 USER jenkins
 
 WORKDIR /src
 
 COPY --chown=jenkins:jenkins ./scripts /scripts
+
+# Create symlinks to renamed test scripts
+RUN ln -s /scripts/test.sh /scripts/test-cc.sh
+RUN ln -s /scripts/sonar.sh /scripts/sonar-cc.sh
 
 # Install dotnet tools
 RUN dotnet tool install --global dotnet-sonarscanner


### PR DESCRIPTION
Theses fixes were merged directly to main last week per this PR
https://github.com/Vestmark/dotnet-build/pull/7

But they should have gone to the release/dotnet-8.0 branch.  The image tag being used by Jenkins is produced by a build trigger listening on the release/dotnet-8.0 branch (not main) in DockerHub.

Fixing that with this PR.