### PR TITLE
Engops 6073 fix symbolic links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,6 @@ WORKDIR /src
 
 COPY --chown=jenkins:jenkins ./scripts /scripts
 
-# Create symlinks to renamed test scripts
-RUN ln -s /scripts/test.sh /scripts/test-cc.sh
-RUN ln -s /scripts/sonar.sh /scripts/sonar-cc.sh
-
 # Install dotnet tools
 RUN dotnet tool install --global dotnet-sonarscanner
 


### PR DESCRIPTION
I apologize for the third go around go here.

The symbolic links removed here were necessary when branching from main but not when correctly branching from release/dotnet-8.0.  In fact, the links were causing the docker image to NOT build, which I did not catch in this morning's PR.

For this branch, the docker image builds and it has been tested in the proposals-api pipeline using replay:
- https://jenkins.vestmarkeng.com/blue/organizations/jenkins/Endeavour%2Fproposals-api%2Fquality-gate/detail/main/179/pipeline/97

Third time is the charm.